### PR TITLE
Added split call to flags

### DIFF
--- a/nvcc.py
+++ b/nvcc.py
@@ -161,7 +161,7 @@ def parse_nvcc_flags(flags):
 
     other_flags = []
 
-    for flag in flags:
+    for flag in flags.split():
         # find which regular expression our flag matches
         # in order to discover which variable to merge the flag into 
         m = re.match(composite_pattern, flag)


### PR DESCRIPTION
Added possible fix for errors thrown if ParseConfig is used in SConstruct.
For example adding
```python
env.ParseConfig('pkg-config --cflags --libs python3')
```
causes
```
TypeError: Tried to lookup RootDir '/' as a File.:
  File "/home/steve/jackal/SConstruct", line 194:
    env.ParseConfig('pkg-config python3 --cflags')
  File "/usr/lib/scons/SCons/Environment.py", line 1577:
    return function(self, self.backtick(command))
  File "/usr/lib/scons/SCons/Environment.py", line 1572:
    return env.MergeFlags(cmd, unique)
  File "/usr/lib/scons/SCons/Environment.py", line 815:
    args = self.ParseFlags(args)
  File "/home/steve/jackal/site_scons/site_tools/nvcc-scons/nvcc.py", line 187:
    other_dict = oldParseFlags(other_flags)
  File "/usr/lib/scons/SCons/Environment.py", line 801:
    do_parse(arg)
  File "/usr/lib/scons/SCons/Environment.py", line 672:
    for t in arg: do_parse(t)
  File "/usr/lib/scons/SCons/Environment.py", line 731:
    dict['LIBS'].append(self.fs.File(arg))
  File "/usr/lib/scons/SCons/Node/FS.py", line 1413:
    return self._lookup(name, directory, File, create)
  File "/usr/lib/scons/SCons/Node/FS.py", line 1392:
    return root._lookup_abs(p, fsclass, create)
  File "/usr/lib/scons/SCons/Node/FS.py", line 2413:
    result.must_be_same(klass)
  File "/usr/lib/scons/SCons/Node/FS.py", line 2372:
    Base.must_be_same(self, klass)
  File "/usr/lib/scons/SCons/Node/FS.py", line 652:
    (self.__class__.__name__, self.get_internal_path(), klass.__name__))
```